### PR TITLE
Task#121454

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-stdnum==1.1
+python-stdnum
 suds
 requests
 unicodecsv


### PR DESCRIPTION
fix: Estaba congelada la versión del python-stdnum y han incorporado formatos de vat válidos para muchos países desde entonces.
https://github.com/arthurdejong/python-stdnum/blob/fc766bc3869bc100516431eebb3aa5e2a19da1a1/stdnum/nl/btw.py#L42